### PR TITLE
Fixed a bug where program would crash on cancelling file import

### DIFF
--- a/python/libopenimu/qt/ImportManager.py
+++ b/python/libopenimu/qt/ImportManager.py
@@ -101,7 +101,7 @@ class ImportManager(QDialog):
         else:
             file = QFileDialog().getExistingDirectory(caption="Sélectionnez le répertoire à importer")
 
-        if file[0]:
+        if len(file) > 0:
             if not self.import_dirs:
                 sep = ";"
                 self.UI.txtFileName.setText(sep.join(file[0]))


### PR DESCRIPTION
- Clicking cancel in the file import dialog would crash
the program because the check 'file[0]' would try to access
the first element of an empty list
- Checking if the list contains any element instead