### PR TITLE
Apple watch importer fixes for new log files and non-chronologic timestamps

### DIFF
--- a/python/libopenimu/importers/AppleWatchImporter.py
+++ b/python/libopenimu/importers/AppleWatchImporter.py
@@ -43,9 +43,9 @@ class AppleWatchImporter(BaseImporter):
     # LOCATION_ID = 0x05
     BEACONS_ID = 0x06
     COORDINATES_ID = 0x7
-    RAW_MOTION_ID = 0x111
-    RAW_ACCELERO_ID = 0x08
-    RAW_GYRO_ID = 0x09
+    RAW_MOTION_ID = 0x8
+    RAW_ACCELERO_ID = 0x9
+    RAW_GYRO_ID = 0x10
 
     def __init__(self, manager: DBManager, participant: Participant):
         super().__init__(manager, participant)


### PR DESCRIPTION
The Apple Watch loggers now logs raw_accelerometer and raw_gyroscope data into separate files. It logs those separately for timestamp exactitude reasons. The data is saved the same way into the OpenIMU DB, hence it does not affect the rest of the system.

Fixes data with non-chronological timestamps, simply by doing an insertion sort on the timestamp right after import into memory. Since the data is almost completely sorted, this sort approaches O(n). On a 15 seconds import into the DB of a 170Mb test file, the sort takes a tad less than a second (on my system).

This version of the importer is also about 4x faster, going from 76 seconds to 15 seconds on a 170Mb motion file.

Sensoria and Beacons importer still need optimizing, as the import into DB is very long on large files (still second long splits.)