### PR TITLE
Fixing environment creation for conda 4.5.11+

### DIFF
--- a/python/env/CMakeLists.txt
+++ b/python/env/CMakeLists.txt
@@ -77,7 +77,7 @@ else(WIN32)
     # Create environment, will produce python executable
     add_custom_command(
         OUTPUT ${ENV_PATH}/bin/python
-        COMMAND ${CONDA_PATH} install -m -c anaconda -c conda-forge -y -p ${ENV_PATH} python=${PYTHON_VERSION} ${conda_packages}
+        COMMAND ${CONDA_PATH} install -m -c conda-forge -y -p ${ENV_PATH} python=${PYTHON_VERSION} ${conda_packages}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     )
 


### PR DESCRIPTION
- New version of conda (at least on Linux) fails to create the env on the 'anaconda' channel when building the project
- [Conda maintainers comments](https://github.com/conda/conda/issues/7870#issuecomment-431519432) that this is an internal channel and should not be used by users
- Although it should probably be fixed for windows as well, I do not have a Win environment to test on, hence left it as is.